### PR TITLE
pubspec file update.

### DIFF
--- a/lib/http_client_with_middleware.dart
+++ b/lib/http_client_with_middleware.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 import 'package:collection/collection.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/http.dart';
+import 'package:http/io_client.dart';
 import 'package:http_middleware/http_methods.dart';
 import 'package:http_middleware/models/request_data.dart';
 import 'package:http_middleware/models/response_data.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,62 +7,84 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.7"
+    version: "2.2.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.6"
+    version: "1.14.11"
   http:
     dependency: "direct main"
     description:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.3+16"
+    version: "0.12.0+2"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.3"
+  meta:
+    dependency: transitive
+    description:
+      name: meta
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.7"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.1"
+    version: "1.6.2"
+  pedantic:
+    dependency: transitive
+    description:
+      name: pedantic
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.5.0"
   source_span:
     dependency: transitive
     description:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.5"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.4"
+  term_glyph:
+    dependency: transitive
+    description:
+      name: term_glyph
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.5"
+    version: "1.1.6"
 sdks:
-  dart: ">=2.0.0-dev.23.0 <=2.0.0-dev.58.0.flutter-f981f09760"
+  dart: ">=2.1.1-dev.0.0 <3.0.0"
+  flutter: ">=0.1.4 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ author: Gurleen Sethi <sarusethi@rocketmail.com>
 homepage: https://github.com/gurleensethi/http_middleware
 
 dependencies:
-  http: ^0.12.0+2
+  http: ^0.12.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ author: Gurleen Sethi <sarusethi@rocketmail.com>
 homepage: https://github.com/gurleensethi/http_middleware
 
 dependencies:
-  http: ^0.12.0
+  http: ^0.12.0+2
 
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec


### PR DESCRIPTION
The issue is that the pubspec.lock holds the actual value that the plugin is using, so in order for the issue #8 to be fixed you needed just to do a `flutter packages get` and then update master branch with that generated `pubspec.lock`. I also updated the file ` lib/http_client_with_middleware.dart` so it now uses the IOClient from the `http` plugin, I think it was moved in the newer versions.